### PR TITLE
Fix CrawlTest

### DIFF
--- a/SearchEngine.iml
+++ b/SearchEngine.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -38,5 +38,7 @@
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:ST4:4.0.8" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.5.2" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:3.12.0" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:1.15.0" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.12.0</version>
+        </dependency>
 
     </dependencies>
     

--- a/src/main/java/HTTPFetcher.java
+++ b/src/main/java/HTTPFetcher.java
@@ -11,6 +11,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -29,6 +32,9 @@ public class HTTPFetcher {
 	public static enum HTTP {
 		OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT
 	};
+
+	/** HTTP client Singleton that will be reused */
+	private static OkHttpClient client = new OkHttpClient();
 
 	private static Logger logger = LogManager.getLogger();
 
@@ -69,27 +75,46 @@ public class HTTPFetcher {
 		return lines;
 	}
 
+
 	/**
-	 * Crafts a minimal HTTP/1.1 request for the provided method.
-	 * 
+	 * Crafts an HTTP request for the provided method.
+	 *
 	 * @param url
 	 *            - url to fetch
 	 * @param type
 	 *            - HTTP method to use
-	 * 
-	 * @return HTTP/1.1 request
-	 * 
+	 *
+	 * @param body
+	 * 			  - body to be sent
+	 *
+	 * @return Request instance
+	 *
 	 * @see {@link HTTP}
+	 * @see {@link Request}
 	 */
-	public static String craftHTTPRequest(URL url, HTTP type) {
-		String host = url.getHost();
-		String resource = url.getFile().isEmpty() ? "/" : url.getFile();
+	public static Request craftHTTPRequest(URL url, HTTP type, RequestBody body) {
 
-		// The specification is specific about where to use a new line
-		// versus a carriage return!
-		return String.format("%s %s %s\r\n" + "Host: %s\r\n"
-				+ "Connection: close\r\n" + "\r\n", type.name(), resource,
-				version, host);
+		return new Request.Builder().url(url).method(type.name(),body).build();
+
+	}
+
+	/**
+	 * Crafts an HTTP request for the provided method.
+	 *
+	 * @param url
+	 *            - url to fetch
+	 * @param type
+	 *            - HTTP method to use
+	 *
+	 * @return Request instance
+	 *
+	 * @see {@link HTTP}
+	 * @see {@link Request}
+	 */
+	public static Request craftHTTPRequest(URL url, HTTP type) {
+
+		return craftHTTPRequest(url, type, (RequestBody) null);
+
 	}
 
 	/**

--- a/src/test/java/CrawlTest.java
+++ b/src/test/java/CrawlTest.java
@@ -33,14 +33,14 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testJustURL() {
 			String[] args = new String[] {ProjectTest.URL_FLAG,
-			        "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html"};
+			        "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html"};
 			ProjectTest.checkExceptions("Only URL", args);
 		}
 
 		@Test(timeout = TIMEOUT)
 		public void testBadURL() {
 			String[] args = new String[] {ProjectTest.URL_FLAG,
-			        "http://www.cs.usfca.edu/~sjengle/nowhere.html"};
+			        "https://www.cs.usfca.edu/~sjengle/nowhere.html"};
 			ProjectTest.checkExceptions("Invalid URL", args);
 		}
 	}
@@ -58,7 +58,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexBirds() {
 			String test = "birds";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -66,7 +66,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchBirds() {
 			String test = "birds";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -74,7 +74,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexYellow() {
 			String test = "yellow";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -82,7 +82,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchYellow() {
 			String test = "yellow";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -90,7 +90,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexHolmes() {
 			String test = "holmes";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -98,7 +98,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchHolmes() {
 			String test = "holmes";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -106,7 +106,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexGuten() {
 			String test = "gutenweb";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -114,7 +114,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchGuten() {
 			String test = "gutenweb";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -122,7 +122,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexRecurse() {
 			String test = "recurse";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -130,7 +130,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchRecurse() {
 			String test = "recurse";
-			String link = "http://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
+			String link = "https://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
 
 			testCrawlSearchOutput(test, link);
 		}

--- a/src/test/java/CrawlTest.java
+++ b/src/test/java/CrawlTest.java
@@ -33,14 +33,14 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testJustURL() {
 			String[] args = new String[] {ProjectTest.URL_FLAG,
-			        "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html"};
+			        "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html"};
 			ProjectTest.checkExceptions("Only URL", args);
 		}
 
 		@Test(timeout = TIMEOUT)
 		public void testBadURL() {
 			String[] args = new String[] {ProjectTest.URL_FLAG,
-			        "https://www.cs.usfca.edu/~sjengle/nowhere.html"};
+			        "http://www.cs.usfca.edu/~sjengle/nowhere.html"};
 			ProjectTest.checkExceptions("Invalid URL", args);
 		}
 	}
@@ -58,7 +58,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexBirds() {
 			String test = "birds";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -66,7 +66,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchBirds() {
 			String test = "birds";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/birds.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -74,7 +74,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexYellow() {
 			String test = "yellow";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -82,7 +82,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchYellow() {
 			String test = "yellow";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/yellowthroat.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -90,7 +90,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexHolmes() {
 			String test = "holmes";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -98,7 +98,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchHolmes() {
 			String test = "holmes";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/gutenberg/1661-h.htm";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -106,7 +106,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexGuten() {
 			String test = "gutenweb";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -114,7 +114,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchGuten() {
 			String test = "gutenweb";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/crawl/gutenberg.html";
 
 			testCrawlSearchOutput(test, link);
 		}
@@ -122,7 +122,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testIndexRecurse() {
 			String test = "recurse";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
 
 			testCrawlIndexOutput(test, link);
 		}
@@ -130,7 +130,7 @@ public class CrawlTest {
 		@Test(timeout = TIMEOUT)
 		public void testSearchRecurse() {
 			String test = "recurse";
-			String link = "https://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
+			String link = "http://www.cs.usfca.edu/~sjengle/cs212/recurse/link01.html";
 
 			testCrawlSearchOutput(test, link);
 		}


### PR DESCRIPTION
CrawlTest was failing due to cs.usfca.edu switching to https.
Because the Socket class can't deal with HTTPS had refactor all of the HTTPFetcher class to use OkHttp client.